### PR TITLE
Ensure thought to goal route auth and req data

### DIFF
--- a/src/routes/ai.js
+++ b/src/routes/ai.js
@@ -570,6 +570,12 @@ Make sure:
 router.post('/transform-thought-to-goal', async (req, res) => {
   console.log('POST /api/ai/transform-thought-to-goal - Request received:', req.body);
   try {
+    // Check if user is authenticated (should be set by authMiddleware)
+    if (!req.user || !req.user.id) {
+      console.log('User not authenticated or missing user ID');
+      return res.status(401).json({ error: 'Authentication required. Please log in to continue.' });
+    }
+
     const { thought } = req.body;
     if (!thought || typeof thought !== 'string') {
       console.log('Invalid thought provided');


### PR DESCRIPTION
Add explicit authentication check and error handling to `/transform-thought-to-goal` route.

The `authMiddleware` is applied globally, but the route previously lacked an explicit check for `req.user` and an early return with a 401 status if the user was not authenticated, addressing the "grt from the req if its missing" part of the original request.